### PR TITLE
feat: allow deep links

### DIFF
--- a/src/routes/+layout.server.js
+++ b/src/routes/+layout.server.js
@@ -1,0 +1,6 @@
+/** @type {import('./$types').LayoutServerLoad} */
+export async function load({ url }) {
+	return {
+		path: url.pathname.slice(1)
+	};
+}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -4,12 +4,18 @@
 	import { page } from '$app/stores';
 	import current from '$lib/store';
 
+	/** @type {import('./$types').LayoutData} */
+	export let data;
+
 	// Array with the order of the slides
 	const slides = ['welcome', 'intro'];
+
+	let start = slides.indexOf(data.path);
 
 	const isPresentation = $page.url.searchParams.has('presentation');
 
 	onMount(() => {
+		$current = start > 0 ? start : 0;
 		const unsubscribe = current.subscribe((c) => {
 			if (isPresentation) {
 				goto(`/${slides[c]}?presentation`);


### PR DESCRIPTION
Before this, the presentation always resets to slide 0 in the slides array on any URL, 404 or otherwise.

After this, deep links work.